### PR TITLE
add snapshot offchain vote post

### DIFF
--- a/_posts/snapshot-offchain-vote.md
+++ b/_posts/snapshot-offchain-vote.md
@@ -1,0 +1,41 @@
+---
+title: "Obtain outcome of off-chain vote"
+summary: "This function fetches the final outcome of an off-chain vote on the Snapshot.org platform"
+date: "2023-02-10"
+author:
+  name: mykcryptodev
+  link: https://twitter.com/mykcryptodev
+---
+
+const proposalId = args[0]
+
+// Use snapshot's graphql API to get the final vote outcome
+const snapshotRequest = () => Functions.makeHttpRequest({
+  url: `https://hub.snapshot.org/graphql`,
+  method: "POST",
+  data: {
+    query: `{
+      proposal(id: "${proposalId}") {
+        choices
+        scores
+        scores_state
+      }
+    }`,
+  },
+})
+
+const { data, error } = await snapshotRequest()
+
+if (error) {
+  throw Error("Snapshot request failed")
+}
+
+const { proposal } = data.data
+const { choices, scores, scores_state } = proposal
+
+if (scores_state !== "final") {
+  throw Error("Snapshot vote is not final")
+}
+
+const winningChoice = choices[scores.indexOf(Math.max(...scores))]
+return Functions.encodeString(winningChoice)


### PR DESCRIPTION
This PR adds the following file: _posts/snapshot-offchain-vote.md
The file contains a function that fetches the final outcome of an off-chain vote that took place on Snapshot.org given the proposal ID

Arguments:
Proposal ID (1st and only argument)

Secrets:
none

expectedReturnType:
ReturnType.string